### PR TITLE
修复：1）下载中文命名的文件，下载框文件名为UTF-8编码而非原本的中文名；2）配置了server.context-path时，登录页跳转…

### DIFF
--- a/src/main/kotlin/com/xhstormr/browse/controller/BrowseController.kt
+++ b/src/main/kotlin/com/xhstormr/browse/controller/BrowseController.kt
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
 import org.yaml.snakeyaml.util.UriEncoder
 import java.io.FileNotFoundException
+import java.nio.charset.Charset
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.stream.Collectors
@@ -52,7 +53,7 @@ class BrowseController(
             }
             Files.isRegularFile(file) -> {
                 response.contentType = MimeTypeUtils.APPLICATION_OCTET_STREAM_VALUE
-                response.setHeader("Content-Disposition", "attachment; filename=${UriEncoder.encode(file.fileName.toString())}")
+                response.setHeader("Content-Disposition", "attachment; filename=${file.fileName.toString().toByteArray().toString(Charset.forName("ISO-8859-1"))}")
                 Files.copy(file, response.outputStream)
                 return null
             }

--- a/src/main/kotlin/com/xhstormr/browse/interceptor/LoginInterceptor.kt
+++ b/src/main/kotlin/com/xhstormr/browse/interceptor/LoginInterceptor.kt
@@ -9,7 +9,7 @@ class LoginInterceptor : HandlerInterceptorAdapter() {
             if (request.session.getAttribute("isLogin") == true) {
                 true
             } else {
-                response.sendRedirect("/login")
+                response.sendRedirect(request.contextPath + "/login")
                 false
             }
 }


### PR DESCRIPTION
第一个就不说了，第二个的话，如果配置server.context-path=/browse，第一次访问时会跳转到/login而不是/browse/login，导致找不到页面，都是一些小问题，随便修复了一下~感谢你的代码，写的非常好